### PR TITLE
Use filter groups to filter webhooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Terraform Version
 This module was created using Terraform 0.11.8.
 So to be more safe, Terraform version 0.11.8 or newer is required to use this module.
 
+This also requires the "aws" terraform provider to be 2.14.0 or newer
+
 Authors
 -------
 * [Karsten Ari Agathon](https://github.com/karstenaa)

--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,14 @@ module "ci_codebuild_role" {
 
 resource "aws_codebuild_webhook" "ci" {
   project_name = "${aws_codebuild_project.ci.name}"
+
+    filter_group = {
+    filter = {
+      type = "EVENT"
+      pattern = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
+      exclude_matched_pattern = false
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "ci_main" {
@@ -228,6 +236,14 @@ module "cd_codebuild_role" {
 
 resource "aws_codebuild_webhook" "cd" {
   project_name = "${aws_codebuild_project.cd.name}"
+
+  filter_group = {
+    filter = {
+      type = "EVENT"
+      pattern = "PUSH"
+      exclude_matched_pattern = false
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "cd_main" {

--- a/main.tf
+++ b/main.tf
@@ -166,10 +166,16 @@ resource "aws_codebuild_webhook" "ci" {
   project_name = "${aws_codebuild_project.ci.name}"
 
   filter_group = {
+    # only build PRs
     filter = {
-      type                    = "EVENT"
-      pattern                 = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
-      exclude_matched_pattern = false
+      type    = "EVENT"
+      pattern = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
+    }
+
+    # only build PRs to master
+    filter = {
+      type    = "BASE_REF"
+      pattern = "refs/heads/master"
     }
   }
 }
@@ -238,10 +244,16 @@ resource "aws_codebuild_webhook" "cd" {
   project_name = "${aws_codebuild_project.cd.name}"
 
   filter_group = {
+    # only build push events
     filter = {
-      type                    = "EVENT"
-      pattern                 = "PUSH"
-      exclude_matched_pattern = false
+      type    = "EVENT"
+      pattern = "PUSH"
+    }
+
+    # only build pushes to master
+    filter = {
+      type    = "BASE_REF"
+      pattern = "refs/heads/master"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -252,7 +252,7 @@ resource "aws_codebuild_webhook" "cd" {
 
     # only build pushes to master
     filter = {
-      type    = "BASE_REF"
+      type    = "HEAD_REF"
       pattern = "refs/heads/master"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -165,10 +165,10 @@ module "ci_codebuild_role" {
 resource "aws_codebuild_webhook" "ci" {
   project_name = "${aws_codebuild_project.ci.name}"
 
-    filter_group = {
+  filter_group = {
     filter = {
-      type = "EVENT"
-      pattern = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
+      type                    = "EVENT"
+      pattern                 = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
       exclude_matched_pattern = false
     }
   }
@@ -239,8 +239,8 @@ resource "aws_codebuild_webhook" "cd" {
 
   filter_group = {
     filter = {
-      type = "EVENT"
-      pattern = "PUSH"
+      type                    = "EVENT"
+      pattern                 = "PUSH"
       exclude_matched_pattern = false
     }
   }


### PR DESCRIPTION
**Important** 
Require AWS provider >= 2.14

Personally, i have been using aws provider 2.14 on our scripts for a week now. So far so good. No issues.

With this change, 

1. the ci hook will only build PR changed meant for the master branch
2. the cd hook will only build pushes to the master branch

What does this mean?

1. You no longer need to manually configure your github webhooks after running this terraform (no need to select push only, etc)
2. You no longer require to fork the repository (although I would still recommend you to) and only the CI will run for PRs and CD will run for pushes to master