### PR TITLE
Update docker image to v0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To understand better on how to use this module, you can go into examples folder 
 Examples
 --------
 [Simple Example](https://github.com/traveloka/terraform-aws-codebuild-terraform-ci-cd/tree/master/examples/simple)
+
 [Complete Example](https://github.com/traveloka/terraform-aws-codebuild-terraform-ci-cd/tree/master/examples/complete)
 
 Terraform Version

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "compute_type" {
 
 variable "image" {
   type        = "string"
-  default     = "traveloka/codebuild-terraform-ci-cd-image:v0.1.6"
+  default     = "traveloka/codebuild-terraform-ci-cd-image:v0.1.8"
   description = "Docker image used by CodeBuild"
 }
 


### PR DESCRIPTION
This PR enables [terraform module download using ](https://github.com/traveloka/codebuild-terraform-ci-cd-image/commit/5ef5e0d37f3f396184b9e3409ae74e6a72787273)SSH and mitigates [absolute path data source issue](https://github.com/hashicorp/terraform/issues/8204) with [workaround](https://github.com/traveloka/codebuild-terraform-ci-cd-image/commit/f1e97a2b06b795c1dc157138d8ae4f86faa34f40). Kudos to @isen-ng :bowing_man: 