### PR TITLE
Bumped Terraform CI/CD Docker Image to v0.1.11

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "compute_type" {
 
 variable "image" {
   type        = "string"
-  default     = "traveloka/codebuild-terraform-ci-cd-image:v0.1.9"
+  default     = "traveloka/codebuild-terraform-ci-cd-image:v0.1.11"
   description = "Docker image used by CodeBuild"
 }
 


### PR DESCRIPTION
This includes two fixes from `v0.1.9` :
- `v0.1.11` : Extended the regex expression to also include `.tpl` files in `TF_WORKING_DIR` 
- `v0.1.10` : Modify Notify plan message to using collapsible format