### PR TITLE
Add image credentials for CD codebuild

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,6 +218,7 @@ resource "aws_codebuild_project" "cd" {
     compute_type = "${var.compute_type}"
     image        = "${var.image}"
     type         = "LINUX_CONTAINER"
+    image_pull_credentials_type = "${var.image_credentials}"
 
     environment_variable = "${var.cd_env_var}"
   }

--- a/main.tf
+++ b/main.tf
@@ -129,9 +129,9 @@ resource "aws_codebuild_project" "ci" {
   }
 
   environment {
-    compute_type = "${var.compute_type}"
-    image        = "${var.image}"
-    type         = "LINUX_CONTAINER"
+    compute_type                = "${var.compute_type}"
+    image                       = "${var.image}"
+    type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "${var.image_credentials}"
 
     environment_variable = "${var.ci_env_var}"
@@ -215,9 +215,9 @@ resource "aws_codebuild_project" "cd" {
   }
 
   environment {
-    compute_type = "${var.compute_type}"
-    image        = "${var.image}"
-    type         = "LINUX_CONTAINER"
+    compute_type                = "${var.compute_type}"
+    image                       = "${var.image}"
+    type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "${var.image_credentials}"
 
     environment_variable = "${var.cd_env_var}"


### PR DESCRIPTION
Just like CI, the CD also require to pull container from different account, hence we need to specify the image credential for CD codebuild job. Here is a failure example when using version v0.2.9
```
. . .
Error: Error applying plan:

1 error occurred:
        * module.terraform_ci_cd.aws_codebuild_project.cd: 1 error occurred:
        * aws_codebuild_project.cd: [ERROR] Error updating CodeBuild project (arn:aws:codebuild:ap-southeast-1:105676898724:project/eci-terraform-aws-cd): InvalidInputException: Invalid input: cannot use a cross-account ECR image with imagePullCredentialsType CODEBUILD
```