### PR TITLE
Add shell interpreter variable

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -77,6 +77,8 @@ data "aws_iam_policy_document" "this" {
 data "template_file" "ci_buildspec" {
   template = <<EOF
 version: 0.2
+env:
+  shell: ${var.ci_shell}
 phases:
   install:
     commands:
@@ -109,6 +111,8 @@ EOF
 data "template_file" "cd_buildspec" {
   template = <<EOF
 version: 0.2
+env:
+  shell: ${var.cd_shell}
 phases:
   install:
     commands:

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "github_app_installation_id" {
 ######
 # CI #
 ######
+variable "ci_shell" {
+  type        = "string"
+  default     = "bash"
+  description = "The shell command interpreter for CI"
+}
+
 variable "ci_env_var" {
   type = "list"
 
@@ -100,6 +106,12 @@ variable "ci_post_build_commands" {
 ######
 # CD #
 ######
+variable "cd_shell" {
+  type        = "string"
+  default     = "bash"
+  description = "The shell command interpreter for CD"
+}
+
 variable "cd_env_var" {
   type = "list"
 


### PR DESCRIPTION
Add ability to use bash as codebuild shell interpreter. 
https://aws.amazon.com/about-aws/whats-new/2020/06/aws-codebuild-now-supports-additional-shell-environments/