### PR TITLE
adjust bucket naming to have consistent result

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,8 @@ Examples
 
 Terraform Version
 -----------------
-This module was created using Terraform 0.11.8.
-So to be more safe, Terraform version 0.11.8 or newer is required to use this module.
 
-This also requires the "aws" terraform provider to be 2.14.0 or newer
-
+This module require terraform 0.12.
 Authors
 -------
 * [Isen Ng](https://github.com/isen-ng)

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ locals {
 
 module "aws_s3_bucket_artifact_name" {
   source        = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.1"
-  name_prefix   = "${var.product_domain}-terraform-ci-cd-${data.aws_caller_identity.current.account_id}-"
+  name_prefix   = "${var.product_domain}-terraform-ci-cd-${data.aws_caller_identity.current.account_id}"
   resource_type = "s3_bucket"
 }
 


### PR DESCRIPTION
### Description

Close https://github.com/traveloka/terraform-aws-codebuild-terraform-ci-cd/issues/32

Adjust the generated `prefix` to have consistent pattern with s3 bucket naming in previous version. So it only need minor changes to upgrade the module and does not require resource re-creation.

from:

```
 # module.terraform_ci_cd.module.aws_s3_bucket_artifact_name.random_id.this will be created
  + resource "random_id" "this" {
      + b64         = (known after apply)
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + prefix      = "ebi-terraform-ci-cd-595706808273"
    }
```

to:

```
 # module.terraform_ci_cd.module.aws_s3_bucket_artifact_name.random_id.this will be created
  + resource "random_id" "this" {
      + b64         = (known after apply)
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + prefix      = "ebi-terraform-ci-cd-595706808273-"
    }
```
