### PR TITLE
support trigger on other branch, e.g. main branch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,10 +208,10 @@ resource "aws_codebuild_webhook" "ci" {
       pattern = "PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED"
     }
 
-    # only build PRs to master
+    # only build PRs to target branch
     filter {
       type    = "BASE_REF"
-      pattern = "refs/heads/master"
+      pattern = var.git_target_branch
     }
   }
 }
@@ -301,10 +301,10 @@ resource "aws_codebuild_webhook" "cd" {
       pattern = "PUSH"
     }
 
-    # only build pushes to master
+    # only build pushes to target branch
     filter {
       type    = "HEAD_REF"
-      pattern = "refs/heads/master"
+      pattern = var.git_target_branch
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "github_app_installation_id" {
   description = "Terraform CI/CD Github App Installation ID"
 }
 
+variable "git_target_branch" {
+  type        = string
+  default     = "refs/heads/master"
+  description = "Branch reference where the CI/CD should be triggered"
+}
+
 ######
 # CI #
 ######


### PR DESCRIPTION
## Summary
The newer GitHub repository has `master` branch renamed as `main` branch.
Since this module only supports master as the target branch, I introduce a more general variable to allow user to override the target branch.