### PR TITLE
Add script to notify tf apply output to PR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,8 +77,11 @@ locals {
     // Upload Apply Artifact to S3 Bucket
     ". cd-upload-apply-artifact.sh",
 
-    //Update latest-commit-apply on S3 Bucket
+    // Update latest-commit-apply on S3 Bucket
     ". cd-update-latest-commit-apply.sh",
+
+    // Notify Apply Output to Github Pull Request
+    "cd-notify-apply-output-to-github-pr.py",
   ]
 
   # CI Buildspec


### PR DESCRIPTION
**Notes**
- Add cd-notify-apply-output-to-github-pr.py to cd_post_build_commands

**Reason**
- We don't need to add the command manually when using this module and by default terraform ci-cd will notify apply output to github
